### PR TITLE
font size banner

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -32,7 +32,7 @@ img.photo__banner{
   height: 450px;
   width: 50vw;
   padding: 20vh 8% 15vh 12%;
-  font-size: 40px;
+  font-size: 35px;
   letter-spacing: -0.05em;
   font-weight: bold;
   text-align: center;


### PR DESCRIPTION
Changed the font size to fix the overlap.

● Before
<img width="463" alt="Screenshot 2023-01-07 at 00 34 45" src="https://user-images.githubusercontent.com/108004372/211117313-02495f10-3de0-45f5-a1d1-03dbe3d5e0a0.png">

● Now
<img width="463" alt="Screenshot 2023-01-07 at 00 35 42" src="https://user-images.githubusercontent.com/108004372/211117381-e796ea06-d29d-4eea-8d72-d4c0a424692d.png">
